### PR TITLE
chore: Add parallel-lint to lint downgraded source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,8 @@ jobs:
       - name: Downgrade src
         run: php bin/transform-source ${{ env.TARGET_PHP_VERSION_ID }}
 
-      - name: Setup PHP ${{ env.TARGET_PHP_VERSION }}
-        uses: shivammathur/setup-php@v2
-        with:
-            php-version: ${{ env.TARGET_PHP_VERSION }}
-            coverage: none
-        env:
-            COMPOSER_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      - name: Run lint on src
+        run: vendor/bin/parallel-lint src --colors --show-deprecated
 
       - name: Get tag for downgraded release
         id: tag-downgraded

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -14,6 +14,10 @@ on:
       - '**.php'
       - 'phpunit.dist.xml'
 
+env:
+  TARGET_PHP_VERSION: '7.4'
+  TARGET_PHP_VERSION_ID: 70400
+
 jobs:
   extension-tests:
     name: PHPUnit Extension Tests [PHP ${{ matrix.php-version }}]
@@ -54,6 +58,12 @@ jobs:
 
       - name: Install dependencies
         run: composer update --ansi
+
+      - name: Downgrade src
+        run: php bin/transform-source ${{ env.TARGET_PHP_VERSION_ID }}
+
+      - name: Run lint on src
+        run: vendor/bin/parallel-lint src --colors --show-deprecated
 
       - name: Run Extension Tests
         run: vendor/bin/phpunit --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "codeigniter4/shield": "^1.0@beta",
         "friendsofphp/php-cs-fixer": "^3.20",
         "nexusphp/cs-config": "^3.12",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3",


### PR DESCRIPTION
This allows to catch lint errors early on before releases.