### PR TITLE
Fix inference of type of Model::find() to base on framework behavior

### DIFF
--- a/tests/Type/DynamicMethodReturnTypeExtensionTest.php
+++ b/tests/Type/DynamicMethodReturnTypeExtensionTest.php
@@ -38,5 +38,7 @@ final class DynamicMethodReturnTypeExtensionTest extends TypeInferenceTestCase
     public static function provideFileAssertsCases(): iterable
     {
         yield from self::gatherAssertTypes(__DIR__ . '/data/model-find.php');
+
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-7.php');
     }
 }

--- a/tests/Type/data/bug-7.php
+++ b/tests/Type/data/bug-7.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) 2023 CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use CodeIgniter\Shield\Models\UserModel;
+
+use function PHPStan\Testing\assertType;
+
+$users = model(UserModel::class);
+assertType('array{}', $users->find([]));
+assertType('list<CodeIgniter\Shield\Entities\User>', $users->find([1]));
+
+// Model::find() does not fail if not `array|int|string|null` but defaults to get all
+assertType('list<CodeIgniter\Shield\Entities\User>', $users->find(new \stdClass()));


### PR DESCRIPTION
Fixes #7 

This is based on https://github.com/codeigniter4/CodeIgniter4/blob/79c1b2f7868642d3de9342817ccad93835765a91/system/Model.php#L182-L203.

To fix that `category_id` is inferred as `mixed`, the array shape should be defined, something like:
```diff
   /**
     * Recalculate stats for thread.
     *
+    * @param array{data: array{category_id: int}} $data
+    *
     * @throws ReflectionException
     */
    protected function recalculateStats(array $data)
```